### PR TITLE
feat(extension): adds an extension operation for installing timescale to be used in migrations

### DIFF
--- a/timescale/db/operations.py
+++ b/timescale/db/operations.py
@@ -1,0 +1,6 @@
+from django.contrib.postgres.operations import CreateExtension
+
+
+class TimescaleExtension(CreateExtension):
+    def __init__(self):
+        self.name = "timescaledb"


### PR DESCRIPTION
When setting up timescaledb on a database an extension is required to be installed - this allows the process to be done in django via use of a custom extension. Developers can choose to do this themselves or add this as part of a migration.