### PR TITLE
fix: pkey name overflow

### DIFF
--- a/timescale/db/backends/postgresql/schema.py
+++ b/timescale/db/backends/postgresql/schema.py
@@ -78,7 +78,7 @@ class TimescaleSchemaEditor(DatabaseSchemaEditor):
         """
         db_table = model._meta.db_table
         table = self.quote_name(db_table)
-        pkey = self.quote_name(f'{db_table}_pkey')
+        pkey = self.quote_name(f'{db_table[:58]}_pkey')
 
         sql = self.sql_drop_primary_key.format(table=table, pkey=pkey)
 


### PR DESCRIPTION
[pkey name overflow happened if table name length is more than 58 symbols](https://github.com/jamessewell/django-timescaledb/issues/47)